### PR TITLE
Rename package

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
-# rollup-swc-preserve-directives
+# rollup-preserve-directives
 
 A rollup plugin helps preserving shebang and string directives in your code.
 
 ## Install
 
 ```bash
-npm install rollup-swc-preserve-directives
+npm install rollup-preserve-directives
 ```
 
 ## Usage
 
 ```js
-import swcPreserveDirectives from 'rollup-swc-preserve-directives';
+import preserveDirectives from 'rollup-preserve-directives';
 
 export default {
   input: './src/index.js',
@@ -20,7 +20,7 @@ export default {
     format: 'cjs'
   },
   plugins: [
-    swcPreserveDirectives()
+    preserveDirectives()
   ]
 }
 ```

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "rollup-swc-preserve-directives",
+  "name": "rollup-preserve-directives",
   "version": "0.7.0",
   "description": "Rollup plugin to preserve directives with SWC",
   "types": "./dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -69,7 +69,7 @@ function swcPreserveDirective(): Plugin {
         } catch (e) {
           this.warn({
             code: 'PARSE_ERROR',
-            message: `[rollup-swc-preserve-directives]: failed to parse "${id}" and extract the directives. make sure you have added "rollup-swc-preserve-directives" to the last of your plugins list, after swc/babel/esbuild/typescript or any other transform plugins.`
+            message: `[rollup-preserve-directives]: failed to parse "${id}" and extract the directives. make sure you have added "rollup-preserve-directives" to the last of your plugins list, after swc/babel/esbuild/typescript or any other transform plugins.`
           });
 
           console.warn(e);


### PR DESCRIPTION
Since we're not fully relying on `swc/core` now and rollup is using swc for parsing since v4, and thanks to @SukkaW 's awesome PR #13 that we don't need to have swc as a peer dependency.

We're going to rename the package to `rollup-preserve-directives` and deprecate `rollup-swc-preserve-directives`