### PR TITLE
fix: `@napi-rs/magic-string` can't handle `\x00`

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,9 +32,10 @@
     "rollup": "^2.0.0 || ^3.0.0 || ^4.0.0"
   },
   "dependencies": {
-    "@napi-rs/magic-string": "^0.3.4"
+    "magic-string": "^0.30.5"
   },
   "devDependencies": {
+    "@rollup/plugin-commonjs": "^25.0.7",
     "@swc/core": "^1.3.96",
     "@swc/helpers": "^0.5.1",
     "@swc/jest": "^0.2.26",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,7 +1,7 @@
 lockfileVersion: 5.4
 
 specifiers:
-  '@napi-rs/magic-string': ^0.3.4
+  '@rollup/plugin-commonjs': ^25.0.7
   '@swc/core': ^1.3.96
   '@swc/helpers': ^0.5.1
   '@swc/jest': ^0.2.26
@@ -11,6 +11,7 @@ specifiers:
   acorn: ^8.10.0
   bunchee: ^3.6.1
   jest: ^29.6.1
+  magic-string: ^0.30.5
   rollup: ^3.28.1
   rollup-plugin-swc3: ^0.9.0
   rollup2: npm:rollup@^2.79.1
@@ -18,9 +19,10 @@ specifiers:
   typescript: ^5.1.6
 
 dependencies:
-  '@napi-rs/magic-string': 0.3.4
+  magic-string: 0.30.5
 
 devDependencies:
+  '@rollup/plugin-commonjs': 25.0.7_rollup@3.28.1
   '@swc/core': 1.3.96_@swc+helpers@0.5.1
   '@swc/helpers': 0.5.1
   '@swc/jest': 0.2.26_@swc+core@1.3.96
@@ -656,7 +658,6 @@ packages:
 
   /@jridgewell/sourcemap-codec/1.4.15:
     resolution: {integrity: sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==}
-    dev: true
 
   /@jridgewell/trace-mapping/0.3.18:
     resolution: {integrity: sha512-w+niJYzMHdd7USdiH2U6869nqhD2nbfZXND5Yp93qIbEmnDNk7PD48o+YchRVpzMU7M6jVCbenTR7PA1FLQ9pA==}
@@ -671,6 +672,7 @@ packages:
     cpu: [arm]
     os: [android]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@napi-rs/magic-string-android-arm64/0.3.4:
@@ -679,6 +681,7 @@ packages:
     cpu: [arm64]
     os: [android]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@napi-rs/magic-string-darwin-arm64/0.3.4:
@@ -687,6 +690,7 @@ packages:
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@napi-rs/magic-string-darwin-x64/0.3.4:
@@ -695,6 +699,7 @@ packages:
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@napi-rs/magic-string-freebsd-x64/0.3.4:
@@ -703,6 +708,7 @@ packages:
     cpu: [x64]
     os: [freebsd]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@napi-rs/magic-string-linux-arm-gnueabihf/0.3.4:
@@ -711,6 +717,7 @@ packages:
     cpu: [arm]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@napi-rs/magic-string-linux-arm64-gnu/0.3.4:
@@ -719,6 +726,7 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@napi-rs/magic-string-linux-arm64-musl/0.3.4:
@@ -727,6 +735,7 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@napi-rs/magic-string-linux-x64-gnu/0.3.4:
@@ -735,6 +744,7 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@napi-rs/magic-string-linux-x64-musl/0.3.4:
@@ -743,6 +753,7 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@napi-rs/magic-string-win32-arm64-msvc/0.3.4:
@@ -751,6 +762,7 @@ packages:
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@napi-rs/magic-string-win32-ia32-msvc/0.3.4:
@@ -759,6 +771,7 @@ packages:
     cpu: [ia32]
     os: [win32]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@napi-rs/magic-string-win32-x64-msvc/0.3.4:
@@ -767,6 +780,7 @@ packages:
     cpu: [x64]
     os: [win32]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@napi-rs/magic-string/0.3.4:
@@ -786,6 +800,7 @@ packages:
       '@napi-rs/magic-string-win32-arm64-msvc': 0.3.4
       '@napi-rs/magic-string-win32-ia32-msvc': 0.3.4
       '@napi-rs/magic-string-win32-x64-msvc': 0.3.4
+    dev: true
 
   /@nicolo-ribaudo/semver-v6/6.3.3:
     resolution: {integrity: sha512-3Yc1fUTs69MG/uZbJlLSI3JISMn2UV2rg+1D/vROUqZyh3l6iYHCs7GMp+M40ZD7yOdDbYjJcU1oTJhrc+dGKg==}
@@ -808,6 +823,24 @@ packages:
       is-reference: 1.2.1
       magic-string: 0.27.0
       rollup: 3.20.7
+    dev: true
+
+  /@rollup/plugin-commonjs/25.0.7_rollup@3.28.1:
+    resolution: {integrity: sha512-nEvcR+LRjEjsaSsc4x3XZfCCvZIaSMenZu/OiwOKGN2UhQpAYI7ru7czFvyWbErlpoGjnSX3D5Ch5FcMA3kRWQ==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^2.68.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+    dependencies:
+      '@rollup/pluginutils': 5.0.2_rollup@3.28.1
+      commondir: 1.0.1
+      estree-walker: 2.0.2
+      glob: 8.1.0
+      is-reference: 1.2.1
+      magic-string: 0.30.5
+      rollup: 3.28.1
     dev: true
 
   /@rollup/plugin-json/6.0.0_rollup@3.20.7:
@@ -888,6 +921,21 @@ packages:
       estree-walker: 2.0.2
       picomatch: 2.3.1
       rollup: 3.20.7
+    dev: true
+
+  /@rollup/pluginutils/5.0.2_rollup@3.28.1:
+    resolution: {integrity: sha512-pTd9rIsP92h+B6wWwFbW8RkZv4hiR/xKsqre4SIuAOaOEQRxi0lqLke9k2/7WegC85GgUs9pjmOjCUi3In4vwA==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0||^3.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+    dependencies:
+      '@types/estree': 1.0.1
+      estree-walker: 2.0.2
+      picomatch: 2.3.1
+      rollup: 3.28.1
     dev: true
 
   /@rollup/rollup-android-arm-eabi/4.4.1:
@@ -2398,12 +2446,11 @@ packages:
       '@jridgewell/sourcemap-codec': 1.4.15
     dev: true
 
-  /magic-string/0.30.1:
-    resolution: {integrity: sha512-mbVKXPmS0z0G4XqFDCTllmDQ6coZzn94aMlb0o/A4HEHJCKcanlDZwYJgwnkmgD3jyWhUgj9VsPrfd972yPffA==}
+  /magic-string/0.30.5:
+    resolution: {integrity: sha512-7xlpfBaQaP/T6Vh8MO/EqXSW5En6INHEvEXQiuff7Gku0PWjU3uf6w/j9o7O+SpB5fOAkrI5HeoNgwjEO0pFsA==}
     engines: {node: '>=12'}
     dependencies:
       '@jridgewell/sourcemap-codec': 1.4.15
-    dev: true
 
   /make-dir/3.1.0:
     resolution: {integrity: sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==}
@@ -2675,7 +2722,7 @@ packages:
       rollup: ^3.0.0
       typescript: ^4.1 || ^5.0
     dependencies:
-      magic-string: 0.30.1
+      magic-string: 0.30.5
       rollup: 3.20.7
       typescript: 5.1.6
     optionalDependencies:

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import type { Plugin, RenderedChunk } from 'rollup'
 import type { Node } from 'estree'
 import { extname } from 'path'
-import { MagicString } from '@napi-rs/magic-string'
+import MagicString from 'magic-string'
 
 const availableESExtensionsRegex = /\.(m|c)?(j|t)sx?$/
 const directiveRegex = /^use (\w+)$/
@@ -122,7 +122,7 @@ function preserveDirective(): Plugin {
 
         return {
           code: magicString ? magicString.toString() : code,
-          map: magicString ? magicString.generateMap({ hires: true }).toMap() : null
+          map: magicString ? magicString.generateMap({ hires: true }) : null
         }
       }
     },
@@ -163,7 +163,7 @@ function preserveDirective(): Plugin {
 
       return {
         code: magicString ? magicString.toString() : code,
-        map: (sourcemap && magicString) ? magicString.generateMap({ hires: true }).toMap() : null
+        map: (sourcemap && magicString) ? magicString.generateMap({ hires: true }) : null
       }
     },
 

--- a/test/__snapshots__/index.test.ts.snap
+++ b/test/__snapshots__/index.test.ts.snap
@@ -1,5 +1,24 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`preserve-directive (rollup 2) fix string constant introduced by rollup commonjs 1`] = `
+{
+  "index": "import require$$0 from 'react';
+
+function getDefaultExportFromCjs (x) {
+	return x && x.__esModule && Object.prototype.hasOwnProperty.call(x, 'default') ? x['default'] : x;
+}
+
+const { useState } = require$$0;
+var commonjsVirtualModules = function client() {
+    return useState(null);
+};
+var index = /*@__PURE__*/ getDefaultExportFromCjs(commonjsVirtualModules);
+
+export { index as default };
+",
+}
+`;
+
 exports[`preserve-directive (rollup 2) issue #9 1`] = `
 {
   "index": "'use strict';
@@ -119,6 +138,25 @@ console.log('shebang');
 }
 `;
 
+exports[`preserve-directive (rollup 3) fix string constant introduced by rollup commonjs 1`] = `
+{
+  "index": "import require$$0 from 'react';
+
+function getDefaultExportFromCjs (x) {
+	return x && x.__esModule && Object.prototype.hasOwnProperty.call(x, 'default') ? x['default'] : x;
+}
+
+const { useState } = require$$0;
+var commonjsVirtualModules = function client() {
+    return useState(null);
+};
+var index = /*@__PURE__*/ getDefaultExportFromCjs(commonjsVirtualModules);
+
+export { index as default };
+",
+}
+`;
+
 exports[`preserve-directive (rollup 3) issue #9 1`] = `
 {
   "index": "'use strict';
@@ -234,6 +272,25 @@ exports[`preserve-directive (rollup 3) should preserve shebang 1`] = `
 {
   "index": "#!/usr/bin/env node
 console.log('shebang');
+",
+}
+`;
+
+exports[`preserve-directive (rollup 4) fix string constant introduced by rollup commonjs 1`] = `
+{
+  "index": "import require$$0 from 'react';
+
+function getDefaultExportFromCjs (x) {
+	return x && x.__esModule && Object.prototype.hasOwnProperty.call(x, 'default') ? x['default'] : x;
+}
+
+const { useState } = require$$0;
+var commonjsVirtualModules = function client() {
+    return useState(null);
+};
+var index = /*@__PURE__*/ getDefaultExportFromCjs(commonjsVirtualModules);
+
+export { index as default };
 ",
 }
 `;

--- a/test/fixtures/commonjs-virtual-modules/index.js
+++ b/test/fixtures/commonjs-virtual-modules/index.js
@@ -1,0 +1,6 @@
+'use client'
+
+const { useState } = require('react');
+module.exports = function client() {
+  return useState(null)
+}

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -3,6 +3,8 @@ import { rollup as rollup3 } from 'rollup';
 import { rollup as rollup2 } from 'rollup2';
 import { rollup as rollup4 } from 'rollup4';
 
+import rollupPluginCommonjs from '@rollup/plugin-commonjs';
+
 const runTests = (rollupImpl: typeof rollup3, version: number) => {
   it('should preserve shebang', async () => {
     const output = await tester(rollupImpl, {
@@ -43,6 +45,15 @@ const runTests = (rollupImpl: typeof rollup3, version: number) => {
   it('issue #9', async () => {
     const output = await tester(rollupImpl, {
       input: 'prop-types/index.js'
+    });
+
+    expect(output).toMatchSnapshot();
+  });
+
+  it('fix string constant introduced by rollup commonjs', async () => {
+    const output = await tester(rollupImpl, {
+      input: 'commonjs-virtual-modules/index.js',
+      otherPlugins: [rollupPluginCommonjs()]
     });
 
     expect(output).toMatchSnapshot();

--- a/test/testing-utils.ts
+++ b/test/testing-utils.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 import { Module } from 'module';
-import type { rollup } from 'rollup';
+import type { rollup, Plugin as RollupPlugin } from 'rollup';
 
 import { swc } from 'rollup-plugin-swc3';
 import preserveDirective from '../src';
@@ -12,7 +12,8 @@ interface BuildTestOption {
   sourcemap?: boolean,
   dir?: string,
   external?: ExternalOption
-  version?: number
+  version?: number,
+  otherPlugins?: RollupPlugin[]
 }
 
 const DEFAULT_EXTERNAL = ['react', 'react-dom', 'react/jsx-runtime', 'react/jsx-dev-runtime'].concat(Module.builtinModules);
@@ -25,6 +26,7 @@ export const tester = async (
     dir = path.resolve(__dirname, 'fixtures'),
     external = DEFAULT_EXTERNAL,
     version,
+    otherPlugins = []
   }: BuildTestOption = {}
 ) => {
   const build = await rollupImpl({
@@ -40,7 +42,7 @@ export const tester = async (
         return acc;
       }, {});
     })() as any,
-    plugins: [preserveDirective(), swc()] as any, // rollup 2 & rollup 3 type is incompatible
+    plugins: [...otherPlugins, preserveDirective(), swc()] as any, // rollup 2 & rollup 3 type is incompatible
     external,
     onwarn(warning, warn) {
       if (version === 2) {


### PR DESCRIPTION
The  `@rollup/plugin-commonjs` introduces virtual modules when transpiling commonjs modules. In rollup, virtual modules start with `\0` (something like `import virtual from '\x00something'`).

`@napi-rs/magic-string` can't handle `\0` properly, causing `SyntaxError: Unterminated string constant (1:33)`.

The PR fixes that by replacing `@napi-rs/magic-string` with `magic-string`.

@h-a-n-a Would you like to look into this, too?